### PR TITLE
DTR/RTS control

### DIFF
--- a/UE4Duino/Source/UE4Duino/Private/Serial.cpp
+++ b/UE4Duino/Source/UE4Duino/Private/Serial.cpp
@@ -8,10 +8,10 @@
 
 #define BOOL2bool(B) B == 0 ? false : true
 
-USerial* USerial::OpenComPort(bool &bOpened, int32 Port, int32 BaudRate)
+USerial* USerial::OpenComPort(bool &bOpened, int32 Port, int32 BaudRate, bool DTR, bool RTS))
 {
 	USerial* Serial = NewObject<USerial>();
-	bOpened = Serial->Open(Port, BaudRate);
+	bOpened = Serial->Open(Port, BaudRate, DTR, RTS);
 	return Serial;
 }
 
@@ -74,7 +74,7 @@ USerial::~USerial()
 	delete m_OverlappedWrite;
 }
 
-bool USerial::Open(int32 nPort, int32 nBaud)
+bool USerial::Open(int32 nPort, int32 nBaud, bool bDTR, bool bRTS)
 {
 	if (nPort < 0)
 	{
@@ -122,6 +122,23 @@ bool USerial::Open(int32 nPort, int32 nBaud)
 	GetCommState(m_hIDComDev, &dcb);
 	dcb.BaudRate = nBaud;
 	dcb.ByteSize = 8;
+	if (bDTR == true)
+	{ 
+		dcb.fDtrControl = DTR_CONTROL_ENABLE;
+	}
+	else
+	{ 
+		dcb.fDtrControl = DTR_CONTROL_DISABLE;
+	}
+
+	if (bRTS == true)
+	{
+		dcb.fRtsControl = RTS_CONTROL_ENABLE;
+	}
+	else
+	{
+		dcb.fRtsControl = RTS_CONTROL_DISABLE;
+	}
 
 	if (!SetCommState(m_hIDComDev, &dcb) ||
 		!SetupComm(m_hIDComDev, 10000, 10000) ||

--- a/UE4Duino/Source/UE4Duino/Public/Serial.h
+++ b/UE4Duino/Source/UE4Duino/Public/Serial.h
@@ -46,10 +46,12 @@ public:
 	 * @param bOpened If the serial port was successfully opened.
 	 * @param Port The serial port to open.
 	 * @param BaudRate BaudRate to open the serial port with.
+	 * @param DTR Enable/Disable DTR communication protocol.
+	 * @param RTS Enable/Disable RTS communication protocol.
 	 * @return A Serial instance to work with the opened port.
 	 */
 	UFUNCTION(BlueprintCallable, meta = (DisplayName = "Open Serial Port"), Category = "UE4Duino", meta = (Keywords = "com arduino serial start"))
-	static USerial* OpenComPort(bool &bOpened, int32 Port = 1, int32 BaudRate = 9600);
+	static USerial* OpenComPort(bool &bOpened, int32 Port = 1, int32 BaudRate = 9600, bool DTR = true, bool RTS = true);
 
 	/**
 	 * Utility function to convert 4 bytes into an Integer. If the input array's length is not 4, returns 0.
@@ -94,10 +96,12 @@ public:
 	 *
 	 * @param Port The serial port to open.
 	 * @param BaudRate BaudRate to open the serial port with.
+	 * @param DTR enable/disable DTR protocol
+	 * @param RTS enable/disable RTS protocol
 	 * @return If the serial port was successfully opened.
 	 */
 	UFUNCTION(BlueprintCallable, meta=(DisplayName = "Open Port"), Category = "UE4Duino", meta = (Keywords = "com start init"))
-	bool Open(int32 Port = 2, int32 BaudRate = 9600);
+	bool Open(int32 Port = 2, int32 BaudRate = 9600, bool DTR = true, bool RTS = true);
 	/**
 	 * Close and end the communication with the serial port. If not open, do nothing.
 	 */


### PR DESCRIPTION
Add ability to enable/disable DTR and RTS control protocols commonly used by Arduino.  Various models may have issues communicating if they are not first initialized by one or both protocols.